### PR TITLE
Stop caching the run task

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,8 @@ on:
       - master
       - '[1-9]+.[0-9]+.x'
   schedule:
-    - cron: '0 5 * * 1-5'
+    - cron: '0 5 * * 1-5' # Mon-Fri at 5am UTC
+  workflow_dispatch:
 jobs:
   alltests:
     runs-on: ubuntu-latest
@@ -47,6 +48,11 @@ jobs:
           archive=$(utils/download-jdk.sh)
           sudo tar -axf $archive
           echo JDK="$(pwd)/${archive%%.tar.gz}" >> $GITHUB_ENV
+      - name: Show the versions
+        run: |
+          echo "Docker version: $(docker --version)"
+          echo "CRaC JDK version: $($JDK/bin/java -version)"
+          echo "Default JDK version: $(java -version)"
       - name: Run All CRaC Tests
         run: './gradlew runAllCracTests'
         env:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -47,12 +47,16 @@ jobs:
         run: |
           archive=$(utils/download-jdk.sh)
           sudo tar -axf $archive
+          echo "JDK archive: $archive"
           echo JDK="$(pwd)/${archive%%.tar.gz}" >> $GITHUB_ENV
       - name: Show the versions
         run: |
-          echo "Docker version: $(docker --version)"
-          echo "CRaC JDK version: $($JDK/bin/java -version)"
-          echo "Default JDK version: $(java -version)"
+          echo "Docker version"
+          docker --version
+          echo "CRaC JDK version"
+          $JDK/bin/java -version
+          echo "Default JDK version"
+          java -version
       - name: Run All CRaC Tests
         run: './gradlew runAllCracTests'
         env:

--- a/buildSrc/src/main/groovy/io/micronaut/crac/tasks/TestScriptRunnerTask.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/crac/tasks/TestScriptRunnerTask.groovy
@@ -5,7 +5,6 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
@@ -19,7 +18,6 @@ import org.gradle.workers.WorkerExecutor
 import javax.inject.Inject
 import java.util.concurrent.atomic.AtomicBoolean
 
-@CacheableTask
 @CompileStatic
 abstract class TestScriptRunnerTask extends DefaultTask {
 


### PR DESCRIPTION
Docker and the CRaC JDK may have changed since the last run.

Previously, we were caching the result of running the tests, which meant it was always from cache even it Docker or the CRaC JDK had updated.

This change stops caching the TestScriptRunnerTask, so we should run the test script every time this action is scheduled.